### PR TITLE
RF-28824 Allow module to be used by both umd and esm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,22 @@ jobs:
           command: |
             aws s3 sync dist s3://static.rainforestqa.com/rainforest-run-info/ --acl public-read --cache-control max-age=60
 
+  publish_to_npm:
+    docker:
+      - image: circleci/node
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - attach_workspace:
+          at: ~/rainforestapp/rainforest-run-info
+      - run:
+          name: Write NPM Token to ~/.npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: Publish to NPM
+          command: npm publish --access=public
+
   update_jira:
     docker:
       - image: alpine:3.8
@@ -79,6 +95,9 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only:
+                - /^v.*/
       - upload_release:
           context:
             - frontend-s3-sync
@@ -88,6 +107,17 @@ workflows:
           filters:
             branches:
               only: master
+      - publish_to_npm:
+          context:
+            - DockerHub
+            - NPM
+          filters:
+            branches:
+              ignore:
+                - /.*/
+            tags:
+              only:
+                - /^v.*/
       - update_jira:
           requires:
             - upload_release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/rainforest-run-info",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Provides access to information about the currently executed Rainforest QA run test environment.",
   "main": "./dist/main.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.1.0",
   "description": "Provides access to information about the currently executed Rainforest QA run test environment.",
   "main": "./dist/main.js",
+  "exports": {
+    "require": "./dist/main.js",
+    "import": "./src/index.js"
+  },
   "files": [
     "dist",
     "LICENSE.txt",


### PR DESCRIPTION
When attempting to build regenwald with webpack 5 I encountered the following error:
```
Attempted import error: 'fetchRunInfo' is not exported from '@rainforestqa/rainforest-run-info' (imported as 'fetchRunInfo').
ERROR in ./src/app/application.js 57:17-29
export 'fetchRunInfo' (imported as 'fetchRunInfo') was not found in '@rainforestqa/rainforest-run-info' (module has no exports)
```

This is due to a misconfiguration in package.json where type: "module" is specified, which sets the module format to es module, but the file pointed to by the main field (`main: './dist/main.js'`) is using umd as specified in the [webpack config](https://github.com/rainforestapp/rainforest-run-info/blob/0c34a71d53c79babd5a3d1d8d04e07d3ed865cde/webpack.config.cjs).

To fix this we can declare [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) so if users want umd they can use ./dist/main.js while if they want es modules they can use ./src/index.js

The "main" attribute will be ignored by systems that understand "exports", while systems that don't understand "exports" will look at "main" so at worst we are just as broken as before.

I've also added a circleci job to automatically publish to npm when we push a tag, similar to how it works in https://github.com/rainforestapp/wisp