### PR TITLE
RF-2884 fix publish_to_npm job needing checkout and webpack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,8 @@ jobs:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
     steps:
-      - attach_workspace:
-          at: ~/rainforestapp/rainforest-run-info
+      - checkout
+      - install_dependencies
       - run:
           name: Write NPM Token to ~/.npmrc
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
@@ -92,12 +92,9 @@ workflows:
     jobs:
       - test
       - build:
-          filters:
-            branches:
-              only: master
-            tags:
-              only:
-                - /^v.*/
+        filters:
+          branches:
+            only: master
       - upload_release:
           context:
             - frontend-s3-sync
@@ -111,6 +108,8 @@ workflows:
           context:
             - DockerHub
             - NPM
+          requires:
+            - test
           filters:
             branches:
               ignore:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/rainforest-run-info",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Provides access to information about the currently executed Rainforest QA run test environment.",
   "main": "./dist/main.js",
   "exports": {


### PR DESCRIPTION
Just some misconfiguration on the `publish_to_npm` job:
1.  it needs to checkout the code (because it needs to read `package.json`)
2. install dependencies (because the prepublish step needs webpack)
3. doesn't depend on `build` since the prepublish builds