### PR TITLE
RF-28824 create separate workflow for publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,10 +90,7 @@ workflows:
   version: 2
   build_and_upload:
     jobs:
-      - test:
-        filters:
-          tags:
-            only: /^v.*/
+      - test
       - build:
         filters:
           branches:
@@ -107,6 +104,20 @@ workflows:
           filters:
             branches:
               only: master
+      - update_jira:
+          requires:
+            - upload_release
+          context:
+            - DockerHub
+            - update-jira-webhook
+  publish_to_npm:
+    jobs:
+      - test:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
       - publish_to_npm:
           context:
             - DockerHub
@@ -118,9 +129,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-      - update_jira:
-          requires:
-            - upload_release
-          context:
-            - DockerHub
-            - update-jira-webhook

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rainforestqa/rainforest-run-info",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Provides access to information about the currently executed Rainforest QA run test environment.",
   "main": "./dist/main.js",
   "exports": {


### PR DESCRIPTION
I can't for the life of me figure out why the test job wouldn't run on a tag push. Finally got it working by creating a completely separate workflow
<img width="1156" alt="Screen Shot 2023-05-18 at 4 35 34 PM" src="https://github.com/rainforestapp/rainforest-run-info/assets/1696217/9cb5ac3f-b50d-4739-8876-a6691de852ea">
